### PR TITLE
template: support embed.FS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/google/safehtml
 
-go 1.14
+go 1.16
 
 require golang.org/x/text v0.3.3

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -6,6 +6,7 @@ package template
 
 import (
 	"bytes"
+	"embed"
 	"io"
 	"io/ioutil"
 	"log"
@@ -172,6 +173,17 @@ func TestParseGlob(t *testing.T) {
 	parsedTmpl := Must(tmpl.ParseGlob(stringConstant(filepath.Join(dir, "T*.tmpl"))))
 	if parsedTmpl != tmpl {
 		t.Errorf("expected ParseGlob to update template")
+	}
+}
+
+//go:embed testdata
+var testFS embed.FS
+
+func TestParseEmbedFS(t *testing.T) {
+	tmpl := New("root")
+	parsedTmpl := Must(tmpl.ParseEmbedFS(testFS, "testdata/glob_*.tmpl"))
+	if parsedTmpl != tmpl {
+		t.Errorf("expected ParseEmbedFS to update template")
 	}
 }
 


### PR DESCRIPTION
Add ParseEmbedFS and Template.ParseEmbedFS, which accept an embed.FS.

The name is chosen so that `ParseFS` is free if we later decide to
support other implementations of `fs.FS`.

This implies that users of safehtml will need be on Go
1.16. Alternatively, we could put these functions under a go1.16
build tag.

Fixes #7.