### PR TITLE
safehtml: switch URLSanitized to a scheme allowlist

### DIFF
--- a/template/sanitize_test.go
+++ b/template/sanitize_test.go
@@ -446,8 +446,9 @@ func TestSanitize(t *testing.T) {
 			err:    ``,
 		},
 		{
+			// data: is not an allowed scheme; the URL is replaced with InnocuousURL.
 			input:  `<link rel="alternate" href="{{ "data:,\"><script>alert('pwned!')</script>" }}">`,
-			output: `<link rel="alternate" href="data:,%22%3e%3cscript%3ealert%28%27pwned!%27%29%3c/script%3e">`,
+			output: `<link rel="alternate" href="about:invalid#zGoSafez">`,
 			err:    ``,
 		},
 		{
@@ -630,19 +631,21 @@ func TestSanitize(t *testing.T) {
 		},
 		// Attribute value contexts that accept both URL and TrustedResouceURL.
 		{
-			// URL sanitization applied to untrusted string.
+			// data: is not an allowed scheme; replaced with InnocuousURL.
 			input:  `<source src="{{ "data:,\"><script>alert('pwned!')</script>" }}">`,
-			output: `<source src="data:,%22%3e%3cscript%3ealert%28%27pwned!%27%29%3c/script%3e">`,
+			output: `<source src="about:invalid#zGoSafez">`,
 			err:    ``,
 		},
 		{
+			// Pre-validated safehtml.URL and TrustedResourceURL bypass isSafeURL and pass through.
 			input:  `<source src="{{ makeURLForTest "data:,\"><script>alert('pwned!')</script>" }}"> <source src="{{ makeTrustedResourceURLForTest "data:,foo" }}">`,
 			output: `<source src="data:,%22%3e%3cscript%3ealert%28%27pwned!%27%29%3c/script%3e"> <source src="data:,foo">`,
 			err:    ``,
 		},
 		{
+			// data: prefix replaced with InnocuousURL; literal suffix is appended.
 			input:  `<source src="{{ "data:,\"><script>alert('pwned!')</script>" }}my/path">`,
-			output: `<source src="data:,%22%3e%3cscript%3ealert%28%27pwned!%27%29%3c/script%3emy/path">`,
+			output: `<source src="about:invalid#zGoSafezmy/path">`,
 			err:    ``,
 		},
 		{
@@ -835,8 +838,9 @@ func TestSanitize(t *testing.T) {
 			err:    `expected a safehtml.Identifier value`,
 		},
 		{
+			// Schemes not on the allowlist are sanitized to InnocuousURL.
 			input:  `<a {{if 0}}id="{{ "foo:bar" }}"{{else}}href="{{ "unkwnown-scheme:bar" }}"{{end}}>foo</a>`,
-			output: `<a href="unkwnown-scheme:bar">foo</a>`,
+			output: `<a href="about:invalid#zGoSafez">foo</a>`,
 			err:    ``,
 		},
 		// Conditional valueless attribute name.

--- a/template/url_test.go
+++ b/template/url_test.go
@@ -14,18 +14,20 @@ func TestValidateURLPrefix(t *testing.T) {
 		in    string
 		valid bool
 	}{
-		// Allowed schemes or MIME types.
+		// Allowed schemes.
 		{`http:`, true},
 		{`http://www.foo.com/`, true},
 		{`https://www.foo.com/`, true},
 		{`mailto://foo@foo.com.com/`, true},
 		{`ftp://foo.com/`, true},
-		{`data:image/png;base64,abc`, true},
-		{`data:video/mpeg;base64,abc`, true},
-		{`data:audio/ogg;base64,abc`, true},
-		{`data:image/png,abc`, true},
-		{`data:text/html;base64,abc`, true},
 		{`tel:+1-234-567-8901`, true},
+		// data: is not on the allowlist; all data: URLs are rejected regardless
+		// of MIME type to prevent script execution via data:text/html and similar.
+		{`data:image/png;base64,abc`, false},
+		{`data:video/mpeg;base64,abc`, false},
+		{`data:audio/ogg;base64,abc`, false},
+		{`data:image/png,abc`, false},
+		{`data:text/html;base64,abc`, false},
 		// Leading and trailing newlines.
 		{"\nhttp:", false},
 		{"http:\n", false},

--- a/url.go
+++ b/url.go
@@ -103,24 +103,35 @@ var safeURLPattern = regexp.MustCompile(`^(?:([a-z0-9+.-]+):|[^&:\/?#]*(?:[\/?#]
 // isSafeURL matches url to a subset of URLs that will not cause script execution if used in
 // a URL context within a HTML document. Specifically, this method returns true if url:
 //
-//	(a) Starts with an explicit scheme that is not javascript; or
-//	(b) Contains no scheme. To ensure that the URL cannot be interpreted as a
-//	    disallowed scheme URL, the runes ':', and '&' may only appear
-//	    after one of the runes [/?#].
+//	(a) Starts with an explicit scheme from the allowlist of known-safe schemes; or
+//	(b) Contains no scheme (relative URL).
+//
+// An allowlist is used rather than a denylist so that schemes not yet on the
+// denylist — such as vbscript:, data:, or blob: — do not silently bypass the check.
 func isSafeURL(url string) bool {
 	// Ignore case.
 	url = strings.ToLower(url)
 	submatches := safeURLPattern.FindStringSubmatch(url)
 	if submatches == nil {
-		// No match
+		// No match.
 		return false
 	}
-	if len(submatches) == 0 {
-		// Implicit URL scheme. This is safe
+	// safeURLPattern has exactly one capture group, so FindStringSubmatch
+	// returns nil or a slice of length 2. The len == 0 branch is unreachable;
+	// relative URLs (second regex alternative) produce submatches[1] == "".
+	scheme := submatches[1]
+	if scheme == "" {
+		// No explicit scheme — relative URL. Safe.
 		return true
 	}
-	// Block javascript: URLs
-	return len(submatches) == 2 && submatches[1] != "javascript"
+	// Allowlist of URI schemes safe for use in href/src attributes.
+	// Schemes absent from this list — including javascript:, vbscript:,
+	// data:, and blob: — are rejected and replaced with InnocuousURL.
+	switch scheme {
+	case "http", "https", "mailto", "ftp", "tel":
+		return true
+	}
+	return false
 }
 
 // String returns the string form of the URL.


### PR DESCRIPTION
## Summary

`isSafeURL()` used a single-value denylist — `submatches[1] != "javascript"` — to decide whether a URL scheme is safe. Any scheme other than `javascript:` passed validation, including `vbscript:`, `data:`, and `blob:`, which can execute scripts in real browsers.

**Root cause:**
```go
// Block javascript: URLs  ← only one scheme blocked
return len(submatches) == 2 && submatches[1] != "javascript"
```

**Confirmed bypasses:**
| Input | Result before fix | Impact |
|---|---|---|
| `vbscript:msgbox(document.cookie)` | returned as-is | Script exec in IE11 / legacy Edge |
| `data:text/html,<script>alert(1)</script>` | returned as-is | XSS in all browsers when navigated |
| `blob:https://example.com/...` | returned as-is | Potential JS blob URL execution |

`safehtml` is used as a security primitive — downstream code trusts that a `safehtml.URL` is safe without further validation. A bypass here undermines the XSS prevention guarantee for all consumers.

**Also fixed:** the dead `len(submatches) == 0` branch — `FindStringSubmatch` on a pattern with one capture group never returns a non-nil slice of length 0. Relative URLs now reach the explicit `scheme == ""` check.

## Fix

Replace the denylist with an allowlist of known-safe schemes: `http`, `https`, `mailto`, `ftp`, `tel`. All other schemes are replaced with `InnocuousURL` (`about:invalid#zGoSafez`).

Updated template tests to reflect the stricter scheme validation (`data:` URLs from untrusted strings are now rejected; pre-validated `safehtml.URL` values are unaffected).

Related security report submitted to Google VRP.